### PR TITLE
修复EventSystem一个问题:当同一帧里面，删除一类对象又创建这类对象，由于对象池的存在会导致其update方法跟lateupdat…

### DIFF
--- a/Server/Model/Base/Object/EventSystem.cs
+++ b/Server/Model/Base/Object/EventSystem.cs
@@ -52,7 +52,9 @@ namespace Model
 
 		private Queue<Disposer> loaders = new Queue<Disposer>();
 		private Queue<Disposer> loaders2 = new Queue<Disposer>();
-		
+
+		private readonly HashSet<Disposer> unique = new HashSet<Disposer>();
+
 		public void Add(DLLType dllType, Assembly assembly)
 		{
 			this.assemblies[dllType] = assembly;
@@ -203,10 +205,16 @@ namespace Model
 
 		public void Load()
 		{
+			unique.Clear();
 			while (this.loaders.Count > 0)
 			{
 				Disposer disposer = this.loaders.Dequeue();
 				if (disposer.Id == 0)
+				{
+					continue;
+				}
+
+				if (!this.unique.Add(disposer))
 				{
 					continue;
 				}
@@ -239,9 +247,16 @@ namespace Model
 
 		private void Start()
 		{
+			unique.Clear();
 			while (this.starts.Count > 0)
 			{
 				Disposer disposer = this.starts.Dequeue();
+
+				if (!this.unique.Add(disposer))
+				{
+					continue;
+				}
+
 				if (!this.disposerEvents.TryGetValue(disposer.GetType(), out IObjectEvent objectEvent))
 				{
 					continue;
@@ -260,6 +275,7 @@ namespace Model
 		{
 			this.Start();
 
+			unique.Clear();
 			while (this.updates.Count > 0)
 			{
 				Disposer disposer = this.updates.Dequeue();
@@ -267,6 +283,12 @@ namespace Model
 				{
 					continue;
 				}
+
+				if (!this.unique.Add(disposer))
+				{
+					continue;
+				}
+
 				if (!this.disposerEvents.TryGetValue(disposer.GetType(), out IObjectEvent objectEvent))
 				{
 					continue;

--- a/Unity/Assets/Scripts/Base/Object/EventSystem.cs
+++ b/Unity/Assets/Scripts/Base/Object/EventSystem.cs
@@ -62,7 +62,7 @@ namespace Model
 
 		private Queue<Disposer> updates = new Queue<Disposer>();
 		private Queue<Disposer> updates2 = new Queue<Disposer>();
-
+		
 		private readonly Queue<Disposer> starts = new Queue<Disposer>();
 
 		private Queue<Disposer> loaders = new Queue<Disposer>();
@@ -70,6 +70,10 @@ namespace Model
 
 		private Queue<Disposer> lateUpdates = new Queue<Disposer>();
 		private Queue<Disposer> lateUpdates2 = new Queue<Disposer>();
+
+		private readonly HashSet<Disposer> unique = new HashSet<Disposer>();
+
+
 
 		public void LoadHotfixDll()
 		{
@@ -264,10 +268,16 @@ namespace Model
 
 		public void Load()
 		{
+			unique.Clear();
 			while (this.loaders.Count > 0)
 			{
 				Disposer disposer = this.loaders.Dequeue();
 				if (disposer.Id == 0)
+				{
+					continue;
+				}
+
+				if (!this.unique.Add(disposer))
 				{
 					continue;
 				}
@@ -301,9 +311,15 @@ namespace Model
 
 		private void Start()
 		{
+			unique.Clear();
 			while (this.starts.Count > 0)
 			{
 				Disposer disposer = this.starts.Dequeue();
+
+				if (!this.unique.Add(disposer))
+				{
+					continue;
+				}
 
 				IObjectSystem objectSystem;
 				if (!this.disposerEvents.TryGetValue(disposer.GetType(), out objectSystem))
@@ -324,10 +340,16 @@ namespace Model
 		{
 			this.Start();
 
+			this.unique.Clear();
 			while (this.updates.Count > 0)
 			{
 				Disposer disposer = this.updates.Dequeue();
 				if (disposer.Id == 0)
+				{
+					continue;
+				}
+
+				if (!this.unique.Add(disposer))
 				{
 					continue;
 				}
@@ -361,10 +383,16 @@ namespace Model
 
 		public void LateUpdate()
 		{
+			this.unique.Clear();
 			while (this.lateUpdates.Count > 0)
 			{
 				Disposer disposer = this.lateUpdates.Dequeue();
 				if (disposer.Id == 0)
+				{
+					continue;
+				}
+
+				if (!this.unique.Add(disposer))
 				{
 					continue;
 				}

--- a/Unity/Hotfix/Base/Object/EventSystem.cs
+++ b/Unity/Hotfix/Base/Object/EventSystem.cs
@@ -45,6 +45,8 @@ namespace Hotfix
 		private Queue<Disposer> lateUpdates = new Queue<Disposer>();
 		private Queue<Disposer> lateUpdates2 = new Queue<Disposer>();
 
+		private readonly HashSet<Disposer> unique = new HashSet<Disposer>();
+
 		public EventSystem()
 		{
 			this.disposerEvents.Clear();
@@ -170,10 +172,16 @@ namespace Hotfix
 
 		public void Load()
 		{
+			unique.Clear();
 			while (this.loaders.Count > 0)
 			{
 				Disposer disposer = this.loaders.Dequeue();
 				if (disposer.Id == 0)
+				{
+					continue;
+				}
+
+				if (!this.unique.Add(disposer))
 				{
 					continue;
 				}
@@ -206,9 +214,16 @@ namespace Hotfix
 
 		private void Start()
 		{
+			unique.Clear();
 			while (this.starts.Count > 0)
 			{
 				Disposer disposer = this.starts.Dequeue();
+
+				if (!this.unique.Add(disposer))
+				{
+					continue;
+				}
+
 				if (!this.disposerEvents.TryGetValue(disposer.GetType(), out IObjectSystem objectEvent))
 				{
 					continue;
@@ -227,6 +242,7 @@ namespace Hotfix
 		{
 			this.Start();
 
+			unique.Clear();
 			while (this.updates.Count > 0)
 			{
 				Disposer disposer = this.updates.Dequeue();
@@ -234,6 +250,12 @@ namespace Hotfix
 				{
 					continue;
 				}
+
+				if (!this.unique.Add(disposer))
+				{
+					continue;
+				}
+
 				if (!this.disposerEvents.TryGetValue(disposer.GetType(), out IObjectSystem objectEvent))
 				{
 					continue;
@@ -262,10 +284,16 @@ namespace Hotfix
 
 		public void LateUpdate()
 		{
+			unique.Clear();
 			while (this.lateUpdates.Count > 0)
 			{
 				Disposer disposer = this.lateUpdates.Dequeue();
 				if (disposer.Id == 0)
+				{
+					continue;
+				}
+
+				if (!this.unique.Add(disposer))
 				{
 					continue;
 				}


### PR DESCRIPTION
…e方法一帧调用多次，所以需要加上去重处理